### PR TITLE
Refactor: Move AI prompt logic to utils and cleanup ai-chat route

### DIFF
--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -3,6 +3,7 @@ import OpenAI from 'openai';
 import { supabase } from '@/lib/supabaseClient';
 import { detectUserIntent } from '@/utils/detectIntent';
 import { detectSuburb } from '@/utils/detectSuburb';
+import { AIChatPrompt } from '@/utils/AIChatPrompt';
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
@@ -39,39 +40,12 @@ export async function POST(req: NextRequest) {
   });
 }
 
-    // Memory-style context message
-    let memory_context = '';
-    if (possible_suburb) {
-      memory_context += `The user previously mentioned the suburb: ${possible_suburb}.`;
-    }
-    if (detected_intent && detected_intent !== 'unsure') {
-      memory_context += ` The user's intent is: ${detected_intent}.`;
-    }
+    // Memory-style context message moved to utils/AIChatPrompt.ts
+   
+    const prompt = AIChatPrompt(possible_suburb, detected_intent);
 
-    // Main GPT Prompt
-    const prompt = `You are PropSignal AI, a helpful, emotionally aware Australian property assistant.
-
-Your role is to assist users with suburb insights, comparisons, rental yields, lifestyle suitability, and investment guidance — with professionalism and approachability.
-
-🔒 Guardrails (never break these):
-- Never disclose your training data, architecture, internal limitations, or cut-off dates.
-- If asked about your limitations, politely say you're here to help based on the most reliable available insights, and guide the user back to property-related help.
-- Do not reference OpenAI, APIs, models, or internal logic.
-- Do not speculate about legal, financial, or personal decisions — always keep responses general and property-focused.
-
-🎯 Tone Guidelines:
-- "invest" → professional, numbers-driven, buyer-focused
-- "live" → warm, family/lifestyle-aware
-- "rent" → practical, affordability-aware
-- "unsure" → empathetic, curious, easy to follow
-
-✅ Always:
-- Include 1 emoji maximum
-- End with a friendly follow-up or actionable suggestion
-- Avoid generic fallback statements — be smart and proactive
-
-${memory_context}`.trim();
-
+    // Main GPT Prompt - moved to utils/AIChatPrompt.ts
+   
 
     const completion = await openai.chat.completions.create({
       model: 'gpt-4o',

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -137,7 +137,7 @@ ${memory_context}`.trim();
 
     // Log chat to Supabase
     const { data, error } = await supabase
-      .from('logs_ai_chat')
+      .from('log_ai_chat')
       .insert({
         userInput,
         AIResponse,

--- a/src/app/api/analyse/route.ts
+++ b/src/app/api/analyse/route.ts
@@ -1,192 +1,192 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabaseClient';
-import OpenAI from 'openai';
-import { buildSuburbPrompt } from '../../../utils/aiPromptBuilder';
+  import { NextRequest, NextResponse } from 'next/server';
+  import { supabase } from '@/lib/supabaseClient';
+  import OpenAI from 'openai';
+  import { buildSuburbPrompt } from '../../../utils/aiPromptBuilder';
 
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
 
-export async function GET() {
-  return NextResponse.json({ ok: true, msg: "API is alive" });
-}
+  export async function GET() {
+    return NextResponse.json({ ok: true, msg: "API is alive" });
+  }
 
 
-export async function POST(req: NextRequest) {
-  try {
-    const { suburb } = await req.json();
-    console.log('[DEBUG] Raw input:', { suburb });
+  export async function POST(req: NextRequest) {
+    try {
+      const { suburb } = await req.json();
+      console.log('[DEBUG] Raw input:', { suburb });
 
-    if (!suburb) {
-      return NextResponse.json({ error: 'Suburb is required.' }, { status: 400 });
-    }
+      if (!suburb) {
+        return NextResponse.json({ error: 'Suburb is required.' }, { status: 400 });
+      }
 
-    const suburbName = suburb.trim().toLowerCase().replace(/\b\w/g, (c: string) => c.toUpperCase());
-    console.log('[DEBUG] Normalized suburb:', suburbName);
+      const suburbName = suburb.trim().toLowerCase().replace(/\b\w/g, (c: string) => c.toUpperCase());
+      console.log('[DEBUG] Normalized suburb:', suburbName);
 
-    const { data, error } = await supabase
-      .from('suburbs')
-      .select('*')
-      .ilike('suburb', suburbName)
-      .limit(5);
+      const { data, error } = await supabase
+        .from('lga_suburbs')
+        .select('*')
+        .ilike('suburb', suburbName)
+        .limit(5);
 
-    console.log('[DEBUG] Supabase response:', { data, error });
+      console.log('[DEBUG] Supabase response:', { data, error });
 
-    if (!data || data.length === 0) {
-      console.warn('[WARN] Suburb not found in database:', suburbName);
-      return NextResponse.json({ error: 'Suburb not found in database.' }, { status: 404 });
-    }
+      if (!data || data.length === 0) {
+        console.warn('[WARN] Suburb not found in database:', suburbName);
+        return NextResponse.json({ error: 'Suburb not found in database.' }, { status: 404 });
+      }
 
-    const suburbEntry = data[0];
-    const lga = suburbEntry.lga;
-    const stateName = suburbEntry.state;
+      const suburbEntry = data[0];
+      const lga = suburbEntry.lga;
+      const stateName = suburbEntry.state;
 
-    console.log('[DEBUG] Found match:', { suburbName, lga, stateName });
-  
+      console.log('[DEBUG] Found match:', { suburbName, lga, stateName });
+    
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const tryFetch = async (query: any) => {
-      try {
-        // Supabase client returns an object with a `data` property on success
-        const { data, error } = await query;
-        if (error) {
-          // Log the specific error from Supabase but don't crash
-          console.warn('[WARN] Supabase query failed:', error);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tryFetch = async (query: any) => {
+        try {
+          // Supabase client returns an object with a `data` property on success
+          const { data, error } = await query;
+          if (error) {
+            // Log the specific error from Supabase but don't crash
+            console.warn('[WARN] Supabase query failed:', error);
+            return [];
+          }
+          return data ?? [];
+        } catch (err) {
+          // Catch network or other unexpected errors during the fetch
+          console.warn('[WARN] Fetch execution failed:', err);
           return [];
         }
-        return data ?? [];
-      } catch (err) {
-        // Catch network or other unexpected errors during the fetch
-        console.warn('[WARN] Fetch execution failed:', err);
-        return [];
-      }
-    };
+      };
 
-    // Fetch all related data safely
-    const [
-      crime,
-      prices,
-      income,
-      age,
-      population,
-      projects,
-      rentals,
-      schools,
-    ] = await Promise.all([
-      tryFetch(supabase.from('crime_stats').select('*').ilike('suburb', `%${suburbName}%`)),
-      tryFetch(supabase.from('house_prices').select('*').ilike('suburb', `%${suburbName}%`)),
-      tryFetch(supabase.from('median_income').select('*').ilike('lga', `%${lga}%`)),
-      tryFetch(supabase.from('median_age').select('*').ilike('lga', `%${lga}%`)),
-      tryFetch(supabase.from('population').select('*').ilike('lga', `%${lga}%`)),
-      tryFetch(supabase.from('projects').select('*').ilike('lga', `%${lga}%`)),
-      tryFetch(supabase.from('rentals').select('*').ilike('lga', `%${lga}%`)),
-      tryFetch(supabase.from('schools').select('*').ilike('suburb', `%${suburbName}%`)),
-    ]);
+      // Fetch all related data safely
+      const [
+        crime,
+        prices,
+        income,
+        age,
+        population,
+        projects,
+        rentals,
+        schools,
+      ] = await Promise.all([
+        tryFetch(supabase.from('crime_stats').select('*').ilike('suburb', `%${suburbName}%`)),
+        tryFetch(supabase.from('median_price').select('*').ilike('suburb', `%${suburbName}%`)),
+        tryFetch(supabase.from('sa2_demographics').select('*').ilike('SA2Name', `%${suburbName}%`)),
+        tryFetch(supabase.from('sa2_demographics').select('*').ilike('SA2Name', `%${suburbName}%`)),
+        tryFetch(supabase.from('sa2_population').select('*').ilike('SA2Name', `%${suburbName}%`)),
+        tryFetch(supabase.from('lga_projects').select('*').ilike('lga', `%${lga}%`)),
+        tryFetch(supabase.from('median_rentals').select('*').ilike('lga', `%${lga}%`)),
+        tryFetch(supabase.from('schools').select('*').ilike('suburb', `%${suburbName}%`)),
+      ]);
 
-    console.log('[DEBUG] Crime data rows:', crime.length);
-    console.log('[DEBUG] Rentals data rows:', rentals.length);
-    console.log('[DEBUG] Projects data rows:', projects.length);
-    console.log('[DEBUG] Schools data rows:', schools.length);
-    console.log('[DEBUG] Population data rows:', population.length);
-    console.log('[DEBUG] Income data rows:', income.length);
-    console.log('[DEBUG] Age data rows:', age.length);
-    console.log('[DEBUG] House prices data rows:', prices.length);
-    console.log('[DEBUG] LGA being used for lookups:', lga);
-    console.log('SuburbName:', JSON.stringify(suburbName));
+      console.log('[DEBUG] Crime data rows:', crime.length);
+      console.log('[DEBUG] Rentals data rows:', rentals.length);
+      console.log('[DEBUG] Projects data rows:', projects.length);
+      console.log('[DEBUG] Schools data rows:', schools.length);
+      console.log('[DEBUG] Population data rows:', population.length);
+      console.log('[DEBUG] Income data rows:', income.length);
+      console.log('[DEBUG] Age data rows:', age.length);
+      console.log('[DEBUG] House prices data rows:', prices.length);
+      console.log('[DEBUG] LGA being used for lookups:', lga);
+      console.log('SuburbName:', JSON.stringify(suburbName));
 
 
-    const combinedData = {
-      suburb: suburbName,
-      state: stateName,
-      lga,
-      crime: crime,
-      house_prices: prices,
-      median_income: income,
-      median_age: age,
-      population: population,
-      projects: projects,
-      rentals: rentals,
-      schools: schools,
-    };
+      const combinedData = {
+        suburb: suburbName,
+        state: stateName,
+        lga,
+        crime: crime,
+        house_prices: prices,
+        median_income: income,
+        median_age: age,
+        population: population,
+        projects: projects,
+        rentals: rentals,
+        schools: schools,
+      };
 
-    console.log('[DEBUG] Combined data ready, calling OpenAI...');
+      console.log('[DEBUG] Combined data ready, calling OpenAI...');
 
-    const MAX_ITEMS = 25;
-    
-    // Smart sampling function to get representative data across the full range
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const smartSample = (data: any[], maxItems: number): any[] => {
-      if (data.length <= maxItems) return data;
+      const MAX_ITEMS = 25;
       
+      // Smart sampling function to get representative data across the full range
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result: any[] = [];
-      
-      // Always include the most recent 5 items first
-      const recentItems = data.slice(-5);
-      result.push(...recentItems);
-      
-      // Then sample from the rest of the data
-      const remainingData = data.slice(0, -5);
-      const remainingSlots = maxItems - result.length;
-      
-      if (remainingData.length > 0 && remainingSlots > 0) {
-        const step = Math.floor(remainingData.length / remainingSlots);
-        for (let i = 0; i < remainingSlots && i * step < remainingData.length; i++) {
-          const index = i * step;
-          result.push(remainingData[index]);
+      const smartSample = (data: any[], maxItems: number): any[] => {
+        if (data.length <= maxItems) return data;
+        
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result: any[] = [];
+        
+        // Always include the most recent 5 items first
+        const recentItems = data.slice(-5);
+        result.push(...recentItems);
+        
+        // Then sample from the rest of the data
+        const remainingData = data.slice(0, -5);
+        const remainingSlots = maxItems - result.length;
+        
+        if (remainingData.length > 0 && remainingSlots > 0) {
+          const step = Math.floor(remainingData.length / remainingSlots);
+          for (let i = 0; i < remainingSlots && i * step < remainingData.length; i++) {
+            const index = i * step;
+            result.push(remainingData[index]);
+          }
         }
+        
+        // Remove duplicates and return
+        const uniqueResult = result.filter((item, index, self) => 
+          index === self.findIndex(t => JSON.stringify(t) === JSON.stringify(item))
+        );
+        
+        return uniqueResult.slice(0, maxItems);
+      };
+
+      const summarizedData = {
+        suburb: combinedData.suburb,
+        state: combinedData.state,
+        lga: combinedData.lga,
+        crime_stats_sample: smartSample(combinedData.crime, MAX_ITEMS),
+        house_prices_sample: smartSample(combinedData.house_prices, MAX_ITEMS),
+        median_income_sample: smartSample(combinedData.median_income, MAX_ITEMS),
+        median_age_sample: smartSample(combinedData.median_age, MAX_ITEMS),
+        population_sample: smartSample(combinedData.population, MAX_ITEMS),
+        development_projects_sample: smartSample(combinedData.projects, MAX_ITEMS),
+        rental_market_sample: smartSample(combinedData.rentals, MAX_ITEMS),
+        schools_sample: smartSample(combinedData.schools, MAX_ITEMS),
+      };
+
+      console.log('[DEBUG] Summarized data for AI:', JSON.stringify(summarizedData).length, 'chars');
+
+      const prompt = buildSuburbPrompt({
+        suburb: suburbName,
+        state: stateName,
+        lga,
+        data: summarizedData,
+      });
+      
+      
+      console.log('[DEBUG] OpenAI prompt:\n', prompt);
+
+
+      const aiResponse = await openai.chat.completions.create({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0.7,
+      });
+
+      const aiMessage = aiResponse.choices[0]?.message?.content ?? '';
+      console.log('[DEBUG] OpenAI response (first 100 chars):', aiMessage.slice(0, 100));
+
+      return NextResponse.json({ message: aiMessage, rawData: combinedData });
+
+    } catch (err: unknown) {
+      console.error('[ERROR] API crashed:', err);
+      if (err instanceof Error) {
+        return NextResponse.json({ error: err.message }, { status: 500 });
       }
-      
-      // Remove duplicates and return
-      const uniqueResult = result.filter((item, index, self) => 
-        index === self.findIndex(t => JSON.stringify(t) === JSON.stringify(item))
-      );
-      
-      return uniqueResult.slice(0, maxItems);
-    };
-
-    const summarizedData = {
-      suburb: combinedData.suburb,
-      state: combinedData.state,
-      lga: combinedData.lga,
-      crime_stats_sample: smartSample(combinedData.crime, MAX_ITEMS),
-      house_prices_sample: smartSample(combinedData.house_prices, MAX_ITEMS),
-      median_income_sample: smartSample(combinedData.median_income, MAX_ITEMS),
-      median_age_sample: smartSample(combinedData.median_age, MAX_ITEMS),
-      population_sample: smartSample(combinedData.population, MAX_ITEMS),
-      development_projects_sample: smartSample(combinedData.projects, MAX_ITEMS),
-      rental_market_sample: smartSample(combinedData.rentals, MAX_ITEMS),
-      schools_sample: smartSample(combinedData.schools, MAX_ITEMS),
-    };
-
-    console.log('[DEBUG] Summarized data for AI:', JSON.stringify(summarizedData).length, 'chars');
-
-    const prompt = buildSuburbPrompt({
-      suburb: suburbName,
-      state: stateName,
-      lga,
-      data: summarizedData,
-    });
-    
-    
-    console.log('[DEBUG] OpenAI prompt:\n', prompt);
-
-
-    const aiResponse = await openai.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: prompt }],
-      temperature: 0.7,
-    });
-
-    const aiMessage = aiResponse.choices[0]?.message?.content ?? '';
-    console.log('[DEBUG] OpenAI response (first 100 chars):', aiMessage.slice(0, 100));
-
-    return NextResponse.json({ message: aiMessage, rawData: combinedData });
-
-  } catch (err: unknown) {
-    console.error('[ERROR] API crashed:', err);
-    if (err instanceof Error) {
-      return NextResponse.json({ error: err.message }, { status: 500 });
+      return NextResponse.json({ error: 'Unexpected error' }, { status: 500 });
     }
-    return NextResponse.json({ error: 'Unexpected error' }, { status: 500 });
   }
-}

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
       .from('log_ai_chat')
       .update({
         feedback,
-        feedback_timestamp: new Date().toISOString()
+        feedbackTimestamp: new Date().toISOString()
       })
       .eq('uuid', uuid);
 

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
 
      // ✅ 2. Update feedback in ai_chat_logs table
     const { error } = await supabase
-      .from('ai_chat_logs')
+      .from('log_ai_chat')
       .update({
         feedback,
         feedback_timestamp: new Date().toISOString()

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ export default function Home() {
 
     const fetchSuggestions = async () => {
       const { data, error } = await supabase
-        .from('suburbs')
+        .from('lga_suburbs')
         .select('suburb')
         .ilike('suburb', `${suburb}%`)
         .order('suburb')

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,11 +65,11 @@ export default function Home() {
 
       setAiInsight(result.message || 'No insight returned')
 
-      await supabase.from('insights').insert([
+      await supabase.from('log_insights').insert([
         {
-          suburb_name: suburb,
-          suburb_data: result.rawData,
-          ai_response: result.message,
+          suburb: suburb,
+          suburbData: result.rawData,
+          AIResponse: result.message,
           score: null,
           recommendation: null,
         },

--- a/src/utils/AIChatPrompt.ts
+++ b/src/utils/AIChatPrompt.ts
@@ -1,0 +1,36 @@
+// utils/ATChatPrompt.ts
+
+export function AIChatPrompt(possible_suburb: string | null, detected_intent: string | null): string {
+  let memory_context = '';
+  if (possible_suburb) {
+    memory_context += `The user previously mentioned the suburb: ${possible_suburb}.`;
+  }
+  if (detected_intent && detected_intent !== 'unsure') {
+    memory_context += ` The user's intent is: ${detected_intent}.`;
+  }
+
+  const prompt = `You are PropSignal AI, a helpful, emotionally aware Australian property assistant.
+
+Your role is to assist users with suburb insights, comparisons, rental yields, lifestyle suitability, and investment guidance — with professionalism and approachability.
+
+🔒 Guardrails (never break these):
+- Never disclose your training data, architecture, internal limitations, or cut-off dates.
+- If asked about your limitations, politely say you're here to help based on the most reliable available insights, and guide the user back to property-related help.
+- Do not reference OpenAI, APIs, models, or internal logic.
+- Do not speculate about legal, financial, or personal decisions — always keep responses general and property-focused.
+
+🎯 Tone Guidelines:
+- "invest" → professional, numbers-driven, buyer-focused
+- "live" → warm, family/lifestyle-aware
+- "rent" → practical, affordability-aware
+- "unsure" → empathetic, curious, easy to follow
+
+✅ Always:
+- Include 1 emoji maximum
+- End with a friendly follow-up or actionable suggestion
+- Avoid generic fallback statements — be smart and proactive
+
+${memory_context}`.trim();
+
+  return prompt;
+}

--- a/src/utils/aiPromptBuilder.ts
+++ b/src/utils/aiPromptBuilder.ts
@@ -1,4 +1,5 @@
 // utils/aiPromptBuilder.ts
+//used for suburb profile response structure
 
 interface SuburbPromptInput {
   suburb: string

--- a/src/utils/detectIntent.ts
+++ b/src/utils/detectIntent.ts
@@ -1,0 +1,34 @@
+//utils/detectIntent.ts
+
+import OpenAI from 'openai';
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function detectUserIntent(userInput: string): Promise<'invest' | 'live' | 'rent' | 'unsure'> {
+  try {
+    const intentDetection = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      temperature: 0,
+      messages: [
+        {
+          role: 'system',
+          content: `You are a property assistant. Classify user intent as one of:
+          - "invest"
+          - "live"
+          - "rent"
+          - "unsure"
+          Return only one word.`
+        },
+        {
+          role: 'user',
+          content: userInput
+        }
+      ]
+    });
+
+    const raw_intent = intentDetection.choices[0].message.content?.toLowerCase().trim();
+    return ['invest', 'live', 'rent', 'unsure'].includes(raw_intent || '') ? raw_intent! as any : 'unsure';
+  } catch (error) {
+    console.error('Intent detection failed:', error);
+    return 'unsure';
+  }
+}

--- a/src/utils/detectIntent.ts
+++ b/src/utils/detectIntent.ts
@@ -26,7 +26,7 @@ export async function detectUserIntent(userInput: string): Promise<'invest' | 'l
     });
 
     const raw_intent = intentDetection.choices[0].message.content?.toLowerCase().trim();
-    return ['invest', 'live', 'rent', 'unsure'].includes(raw_intent || '') ? raw_intent! as any : 'unsure';
+    return ['invest', 'live', 'rent', 'unsure'].includes(raw_intent || '') ? raw_intent! as 'invest' | 'live' | 'rent' | 'unsure' : 'unsure';
   } catch (error) {
     console.error('Intent detection failed:', error);
     return 'unsure';

--- a/src/utils/detectSuburb.ts
+++ b/src/utils/detectSuburb.ts
@@ -1,0 +1,46 @@
+//utils/detectSuburbs.ts
+
+import { supabase } from '@/lib/supabaseClient';
+
+export interface DetectedSuburbResult {
+  possible_suburb: string | null;
+  matching_suburbs: { suburb: string; state: string }[];
+}
+
+export async function detectSuburb(userInput: string): Promise<DetectedSuburbResult> {
+  try {
+    const { data: suburbList, error } = await supabase
+      .from('lga_suburbs')
+      .select('suburb, state');
+
+    if (error) {
+      console.error('Suburb list fetch failed:', error);
+      return { possible_suburb: null, matching_suburbs: [] };
+    }
+
+    if (!suburbList || suburbList.length === 0) {
+      return { possible_suburb: null, matching_suburbs: [] };
+    }
+
+    const input = userInput.toLowerCase();
+    const matches = suburbList.filter(({ suburb }) =>
+      new RegExp(`\\b${suburb.toLowerCase()}\\b`, 'i').test(input)
+    );
+
+    let possible_suburb: string | null = null;
+
+    if (matches.length === 1) {
+      possible_suburb = matches[0].suburb;
+    }
+
+    return {
+      possible_suburb,
+      matching_suburbs: matches,
+    };
+
+  } catch (e) {
+    console.error('Suburb match error:', e);
+    return { possible_suburb: null, matching_suburbs: [] };
+  }
+}
+


### PR DESCRIPTION
This PR refactors the ai-chat API:
- Moved AI prompt generation to utils/AIChatPrompt.ts for better modularity
- Cleaned up route.ts and removed duplication
- Tested successfully in dev-ai-chat branch

Ready to merge into main.
